### PR TITLE
Add preliminary SHSolver

### DIFF
--- a/Examples/shsolver_vs_heom.ipynb
+++ b/Examples/shsolver_vs_heom.ipynb
@@ -1,0 +1,301 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c6fe6f1a",
+   "metadata": {},
+   "source": [
+    "# SH Solver vs HEOM Benchmark\n",
+    "\n",
+    "This notebook compares the **SH solver**, implementing the\n",
+    "Stochastic Pseudomode Model from\n",
+    "[PRX Quantum **4**, 030316 (2023)](https://doi.org/10.1103/PRXQuantum.4.030316),\n",
+    "against the **Hierarchical Equations of Motion (HEOM)** reference for a two-level\n",
+    "system coupled to a classical Gaussian bath.\n",
+    "\n",
+    "**Physical setup:**\n",
+    "- Two-level system with Hamiltonian $H_S = \\frac{\\Omega}{2}\\,\\sigma_x$\n",
+    "- Constant classical bath correlation $C_\\text{class}(t) = \\sigma^2$\n",
+    "- Coupling operator $\\hat{s} = \\sigma_z$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11e8a000",
+   "metadata": {},
+   "source": [
+    "## 1. Imports and Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cb35663",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from qutip import (\n",
+    "    basis, spre, spost, expect,\n",
+    "    ExponentialBosonicEnvironment,\n",
+    ")\n",
+    "from qutip.solver.heom import HEOMSolver\n",
+    "\n",
+    "# Ensure the solver module is importable\n",
+    "sys.path.insert(0, str(Path(\"../sumo/Classes\").resolve()))\n",
+    "from shsolver import SHSolver"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b219bf2",
+   "metadata": {},
+   "source": [
+    "## 2. Physical Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b58bf4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Omega = 1\n",
+    "sigma = 0.05 * Omega\n",
+    "T     = 40 / Omega"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b50e953d",
+   "metadata": {},
+   "source": [
+    "## 3. Numerical Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "545c8c4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_corr  = 600\n",
+    "n_cut   = 600\n",
+    "n_noise = 500"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c77f35d1",
+   "metadata": {},
+   "source": [
+    "## 4. Operator Construction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf12f84b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sigmaz = basis(2, 0) * basis(2, 0).dag() - basis(2, 1) * basis(2, 1).dag()\n",
+    "sigmax = basis(2, 1) * basis(2, 0).dag() + basis(2, 0) * basis(2, 1).dag()\n",
+    "\n",
+    "H_S  = Omega / 2.0 * sigmax\n",
+    "psi0 = basis(2, 0)\n",
+    "\n",
+    "L    = -1j * (spre(H_S) - spost(H_S))\n",
+    "H_xi = -1j * (spre(sigmaz) - spost(sigmaz))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6225bf7",
+   "metadata": {},
+   "source": [
+    "## 5. Time Grids and Correlation Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f1660f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t_corr_list     = np.linspace(-T, T, 2 * N_corr + 1)\n",
+    "t_dynamics_list = np.linspace(0, T, N_corr)\n",
+    "\n",
+    "c_corr_list = np.full_like(t_corr_list, sigma**2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a459bf6b",
+   "metadata": {},
+   "source": [
+    "## 6. Run the Stochastic Hamiltonian Solver"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "512e06b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "solver = SHSolver()\n",
+    "\n",
+    "coeff_list = solver.compute_coefficients_basis(t_corr_list, c_corr_list, n_cut)\n",
+    "xi_list    = solver.generate_fields(t_corr_list, coeff_list, n_cut, n_noise)\n",
+    "\n",
+    "dynamics_average, sigma_dynamics, dynamics_list, states_list = (\n",
+    "    solver.average_dynamics_parallel(\n",
+    "        L=L, H_xi=H_xi, xi_list=xi_list,\n",
+    "        c_list=[],\n",
+    "        t_list=t_dynamics_list, t_corr_list=t_corr_list, psi0=psi0,\n",
+    "        n_noise=n_noise, obs_list=[sigmaz],\n",
+    "        args={},\n",
+    "        options={\n",
+    "            \"atol\": 1e-12,\n",
+    "            \"rtol\": 1e-10,\n",
+    "            \"nsteps\": 200000,\n",
+    "            \"store_states\": True,\n",
+    "        },\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d45b3d7",
+   "metadata": {},
+   "source": [
+    "## 7. Run the HEOM Reference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "918a355c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "env = ExponentialBosonicEnvironment([sigma**2], [0.0], [], [])\n",
+    "\n",
+    "heom_solver = HEOMSolver(H_S, (env, sigmaz), max_depth=50)\n",
+    "result_heom = heom_solver.run(psi0 * psi0.dag(), t_dynamics_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78423a37",
+   "metadata": {},
+   "source": [
+    "## 8. Transform to the Lab Frame\n",
+    "\n",
+    "Both solvers work in the interaction picture."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4061b101",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def to_lab_frame(states, H_S, t_list, observable):\n",
+    "    \"\"\"Rotate states to the lab frame and return expectation values.\"\"\"\n",
+    "    rotated = [\n",
+    "        (1j * H_S * t).expm() * rho * (-1j * H_S * t).expm()\n",
+    "        for rho, t in zip(states, t_list)\n",
+    "    ]\n",
+    "    return np.real(expect(observable, rotated))\n",
+    "\n",
+    "sz_heom = to_lab_frame(result_heom.states, H_S, t_dynamics_list, sigmaz)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d513b0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "states_arr = np.array([[rho.full() for rho in traj] for traj in states_list])\n",
+    "sz_matrix  = sigmaz.full()\n",
+    "unitaries  = [(1j * H_S * t).expm().full() for t in t_dynamics_list]\n",
+    "\n",
+    "sz_all = np.array([\n",
+    "    [np.real(np.trace(sz_matrix @ (U @ states_arr[k, t] @ U.conj().T)))\n",
+    "     for t, U in enumerate(unitaries)]\n",
+    "    for k in range(n_noise)\n",
+    "])\n",
+    "\n",
+    "sz_mean = sz_all.mean(axis=0)\n",
+    "sz_sem  = sz_all.std(axis=0) / np.sqrt(n_noise)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48911a4d",
+   "metadata": {},
+   "source": [
+    "## 9. Comparison Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47d0c158",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(6, 3.5))\n",
+    "\n",
+    "ax.plot(t_dynamics_list, sz_heom, linewidth=2.5, label=\"HEOM\", color=\"tab:blue\")\n",
+    "ax.plot(t_dynamics_list, sz_mean, linewidth=2.5, label=\"SPM\", color=\"tab:orange\",\n",
+    "        linestyle=\"--\")\n",
+    "ax.fill_between(\n",
+    "    t_dynamics_list, sz_mean - sz_sem, sz_mean + sz_sem,\n",
+    "    alpha=0.3, color=\"tab:orange\", label=r\"SPM $\\pm$ SEM\",\n",
+    ")\n",
+    "\n",
+    "ax.set_xlabel(r\"Time $t\\;(1/\\Omega)$\", fontsize=12)\n",
+    "ax.set_ylabel(r\"$\\langle \\hat{\\sigma}_z \\rangle$\", fontsize=12)\n",
+    "ax.legend(frameon=False, fontsize=10)\n",
+    "ax.set_title(\"Stochastic Pseudomode Model vs HEOM\", fontsize=13)\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "SUMO",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sumo/Classes/shsolver.py
+++ b/sumo/Classes/shsolver.py
@@ -1,18 +1,21 @@
 import numpy as np
-from qutip import QobjEvo, mesolve
+from qutip import Qobj, QobjEvo, mesolve
 from qutip.solver.parallel import parallel_map
 
 
 class SHSolver:
+    """Solver for stochastic pseudomode models.
+
+    Implements the stochastic unravelling of the classical bath
+    correlation function described in PRX Quantum 4, 030316 (2023).
     """
-    Constructs a stochastic version of the pseudomode-model"""
 
     def __init__(self):
         # TODO: Define class inputs and initialization logic
         pass
 
-    def compute_coefficients_basis(self, t_corr_list: np.array,
-                                     C_list: np.array, n_cut: int) -> np.array:
+    def compute_coefficients_basis(self, t_corr_list: np.ndarray,
+                                   C_list: np.ndarray, n_cut: int) -> np.ndarray:
         """
         Compute the Fourier cosine coefficients of the
         classical bath correlation function. Implements
@@ -46,8 +49,8 @@ class SHSolver:
         coeffs = dt * np.sum(product[:, :-1], axis=1) / (2 * T)
         return coeffs
 
-    def generate_A(self, t_corr_list: np.array, coeff_list: np.array,
-                   n_cut: int) -> np.array:
+    def generate_A(self, t_corr_list: np.ndarray, coeff_list: np.ndarray,
+                   n_cut: int) -> np.ndarray:
         """
         Builds the matrix `A` used to generate the stochastic field ξ(t)
         following Eq. (14) of PRX Quantum 4, 030316 (2023):
@@ -57,7 +60,7 @@ class SHSolver:
         t_corr_list : np.ndarray
             Time grid defining the time domain of ξ(t).
         coeff_list : np.ndarray
-            Coefficients c_n obtained from `compute_coefficients_basis_2`.
+            Coefficients c_n obtained from `compute_coefficients_basis`.
         n_cut : int
 
         Returns
@@ -69,21 +72,21 @@ class SHSolver:
 
         T = t_corr_list[-1]
         n_vec = np.arange(1, n_cut + 1)
-        first_col = np.sqrt(coeff_list[0]) * np.ones((len(t_corr_list), 1))
+        first_col = np.sqrt(coeff_list[0]).astype(complex) * np.ones((len(t_corr_list), 1))
         theta = np.outer(t_corr_list, n_vec) * np.pi / T
         sqrt2 = np.sqrt(2)
-        sqrt_coeffs = np.sqrt(coeff_list[1:n_cut + 1])
+        sqrt_coeffs = np.sqrt(coeff_list[1:n_cut + 1].astype(complex))
         cos_terms = sqrt2 * sqrt_coeffs * np.cos(theta)
         sin_terms = sqrt2 * sqrt_coeffs * np.sin(theta)
-        interleaved = np.empty((len(t_corr_list), 2 * n_cut))
+        interleaved = np.empty((len(t_corr_list), 2 * n_cut), dtype=complex)
         interleaved[:, 0::2] = cos_terms
         interleaved[:, 1::2] = sin_terms
         A = np.concatenate([first_col, interleaved], axis=1)
-
+        
         return A
 
     def generate_xi_list(self, A: np.ndarray, n_cut: int, n_noise: int,
-                         mu: float = 0, sigma: float = 1) -> np.array:
+                         mu: float = 0, sigma: float = 1) -> np.ndarray:
         """
         Generate stochastic realizations of the classical field ξ(t).
 
@@ -91,6 +94,8 @@ class SHSolver:
         independent Gaussian random variables ξ_n with mean `mu` and
         variance `sigma`, then combining them with the deterministic
         basis matrix `A` to form stochastic time-dependent fields ξ(t).
+
+        TODO: Add a seed parameter for reproducibility.
 
         Parameters
         ----------
@@ -143,8 +148,8 @@ class SHSolver:
         xi_list = self.generate_xi_list(A, n_cut, n_noise)
         return xi_list
 
-    def one_run(self, k, L, H_xi, xi_list, c_list, t_list, psi0, obs_list,
-                args, options):
+    def one_run(self, k, L, H_xi, xi_list, c_list, t_list, t_corr_list,
+                psi0, obs_list, args, options):
 
         """
         Solves the stochastic Lindblad equation Eq. (16) in PRX Quantum 4,
@@ -179,18 +184,22 @@ class SHSolver:
         result : np.ndarray
             TODO: add better description
         """
-
         L_m = QobjEvo(
             [L, [H_xi, xi_list[k]]],
-            tlist=np.linspace(t_list[0], t_list[-1], len(xi_list[k])),
+            tlist=t_corr_list,
         )
+
         result = mesolve(
             L_m, psi0, t_list, c_list, obs_list, args=args, options=options
-        ).expect[0]
-        return result
+        )
 
-    def average_dynamics_parallel(self, L, H_xi, xi_list, c_list, t_list, psi0,
-                                  n_noise, obs_list, args, options):
+        if options["store_states"]:
+            return result.expect, result.states
+        else:
+            return result.expect
+
+    def average_dynamics_parallel(self, *, L, H_xi, xi_list, c_list, t_list, t_corr_list,
+                                  psi0, n_noise, obs_list, args, options=None):
         """
         Runs multiple realizations of the stochastic master equation (Eq. 16)
         in parallel using QuTiP’s `parallel_map`.
@@ -220,23 +229,37 @@ class SHSolver:
 
         Returns
         -------
-        dynamics_average : float
-            Mean value of the results.
-        sigma : float
-            Standard deviation of the results.
-        dynamics_list : np.ndarray
-            Individual trajectory results.
+        dynamics_average : np.ndarray
+            Mean expectation value across realizations at each time point.
+        SME : np.ndarray
+            Standard error of the mean.
+        expect_list : list of np.ndarray
+            Individual expectation-value trajectories for each realization.
+        states_list : list of list of Qobj  (only if ``store_states=True``)
+            Full per-realization density-matrix trajectories,
+            ``states_list[k][t]`` gives ρ_k(t).
         """
+
+        if options is None:
+            options = {"store_states": False}
+
+        store_states = options.get("store_states", False)
 
         dynamics_list = parallel_map(
             self.one_run,
             range(n_noise),
-            task_args=(L, H_xi, xi_list, c_list, t_list, psi0,
-                       obs_list, args, options),
+            task_args=(L, H_xi, xi_list, c_list, t_list, t_corr_list,
+                       psi0, obs_list, args, options),
             progress_bar=True)
 
-        dynamics_arr = np.array(dynamics_list)
-        dynamics_average = np.mean(dynamics_arr)
-        sigma = np.std(dynamics_arr)
+        if store_states:
+            expect_list, states_list = zip(*dynamics_list)
+        else:
+            expect_list = dynamics_list
+            states_list = None
 
-        return dynamics_average, sigma, dynamics_list
+        dynamics_arr = np.asarray(expect_list)
+        dynamics_average = np.mean(dynamics_arr, axis=0)
+        SME = np.std(dynamics_arr, axis=0) / np.sqrt(n_noise)
+
+        return dynamics_average, SME, expect_list, states_list

--- a/sumo/Classes/shsolver.py
+++ b/sumo/Classes/shsolver.py
@@ -1,0 +1,242 @@
+import numpy as np
+from qutip import QobjEvo, mesolve
+from qutip.solver.parallel import parallel_map
+
+
+class SHSolver:
+    """
+    Constructs a stochastic version of the pseudomode-model"""
+
+    def __init__(self):
+        # TODO: Define class inputs and initialization logic
+        pass
+
+    def compute_coefficients_basis(self, t_corr_list: np.array,
+                                     C_list: np.array, n_cut: int) -> np.array:
+        """
+        Compute the Fourier cosine coefficients of the
+        classical bath correlation function. Implements
+        Eq. (13) of PRX Quantum 4, 030316 (2023)
+
+        Parameters
+        ----------
+        t_corr_list : np.ndarray
+            Time grid over which the bath correlation
+            function `C_list` is defined.
+        C_list : np.ndarray
+            Discretized values of the classical part of
+            the bath correlation function C_class(t).
+        n_cut : int
+            Truncation order of the Fourier expansion
+            (number of modes).
+
+        Returns
+        -------
+        coeffs : np.ndarray
+            Array of Fourier coefficients `c_n` of length `n_cut + 1`.
+        """
+
+        T = t_corr_list[-1]
+        dt = t_corr_list[1] - t_corr_list[0]
+        t_corr_arr = np.asarray(t_corr_list)
+        n_vec = np.arange(0, n_cut + 1)
+        b = np.pi * t_corr_arr / T
+        basis_matrix = np.cos(n_vec[:, None] @ b[None, :])
+        product = basis_matrix * C_list
+        coeffs = dt * np.sum(product[:, :-1], axis=1) / (2 * T)
+        return coeffs
+
+    def generate_A(self, t_corr_list: np.array, coeff_list: np.array,
+                   n_cut: int) -> np.array:
+        """
+        Builds the matrix `A` used to generate the stochastic field ξ(t)
+        following Eq. (14) of PRX Quantum 4, 030316 (2023):
+
+        Parameters
+        ----------
+        t_corr_list : np.ndarray
+            Time grid defining the time domain of ξ(t).
+        coeff_list : np.ndarray
+            Coefficients c_n obtained from `compute_coefficients_basis_2`.
+        n_cut : int
+
+        Returns
+        -------
+        A : np.ndarray
+            Real-valued matrix of shape (len(t_corr_list), 2 * n_cut + 1)
+            encoding all cosine and sine time functions scaled by √(2 c_n).
+        """
+
+        T = t_corr_list[-1]
+        n_vec = np.arange(1, n_cut + 1)
+        first_col = np.sqrt(coeff_list[0]) * np.ones((len(t_corr_list), 1))
+        theta = np.outer(t_corr_list, n_vec) * np.pi / T
+        sqrt2 = np.sqrt(2)
+        sqrt_coeffs = np.sqrt(coeff_list[1:n_cut + 1])
+        cos_terms = sqrt2 * sqrt_coeffs * np.cos(theta)
+        sin_terms = sqrt2 * sqrt_coeffs * np.sin(theta)
+        interleaved = np.empty((len(t_corr_list), 2 * n_cut))
+        interleaved[:, 0::2] = cos_terms
+        interleaved[:, 1::2] = sin_terms
+        A = np.concatenate([first_col, interleaved], axis=1)
+
+        return A
+
+    def generate_xi_list(self, A: np.ndarray, n_cut: int, n_noise: int,
+                         mu: float = 0, sigma: float = 1) -> np.array:
+        """
+        Generate stochastic realizations of the classical field ξ(t).
+
+        Implements Eq. (14) of PRX Quantum 4, 030316 (2023) by sampling
+        independent Gaussian random variables ξ_n with mean `mu` and
+        variance `sigma`, then combining them with the deterministic
+        basis matrix `A` to form stochastic time-dependent fields ξ(t).
+
+        Parameters
+        ----------
+        A : np.ndarray
+            Basis matrix from `generate_A`.
+        n_cut : int
+
+        n_noise : int
+            Number of stochastic realizations (samples) to generate.
+        mu : float, optional
+            Mean of the Gaussian random variables (default is 0).
+        sigma : float, optional
+            Variance of the Gaussian random variables (default is 1).
+
+        Returns
+        -------
+        xi_fields : np.ndarray
+            Array of shape (n_noise, len(t_corr_list)) containing independent
+            realizations of ξ(t).
+        """
+
+        xi_lists = np.random.normal(mu, sigma, size=(n_noise, 2 * n_cut + 1))
+        xi_fields = xi_lists @ A.T
+
+        return xi_fields
+
+    def generate_fields(self, t_corr_list: np.ndarray, coeff_list: np.ndarray,
+                        n_cut: int, n_noise: int) -> np.ndarray:
+        """
+        Generate a set of ξ(t) trajectories.
+
+        Parameters
+        ----------
+        t_corr_list : np.ndarray
+            Time grid.
+        coeff_list : np.ndarray
+            c_n coefficients.
+        n_cut : int
+
+        n_noise : int
+            Number of stochastic trajectories.
+
+        Returns
+        -------
+        xi_fields : np.ndarray
+            Shape (n_noise, M): the generated ξ_k(t).
+        """
+
+        A = self.generate_A(t_corr_list, coeff_list, n_cut)
+        xi_list = self.generate_xi_list(A, n_cut, n_noise)
+        return xi_list
+
+    def one_run(self, k, L, H_xi, xi_list, c_list, t_list, psi0, obs_list,
+                args, options):
+
+        """
+        Solves the stochastic Lindblad equation Eq. (16) in PRX Quantum 4,
+        030316 (2023) for a single realization of ξ(t),
+        corresponding to the k-th sample.
+
+        Parameters
+        ----------
+        k : int
+            Index of the ξ_k(t) realization.
+        L : qutip.Qobj or qutip.QobjEvo
+            System Liouvillian.
+        H_xi : qutip.Qobj
+            TODO: add a better description
+        xi_list : np.ndarray
+            All ξ(t) trajectories.
+        c_list : list
+            Collapse operators for dissipation.
+        t_list : np.ndarray
+            Integration times.
+        psi0 : qutip.Qobj
+            Initial state.
+        obs_list : list
+            Observables to record (passed to `mesolve`).
+        args : dict
+            Extra arguments for `mesolve`.
+        options : qutip.solver.Options
+            Solver options.
+
+        Returns
+        -------
+        result : np.ndarray
+            TODO: add better description
+        """
+
+        L_m = QobjEvo(
+            [L, [H_xi, xi_list[k]]],
+            tlist=np.linspace(t_list[0], t_list[-1], len(xi_list[k])),
+        )
+        result = mesolve(
+            L_m, psi0, t_list, c_list, obs_list, args=args, options=options
+        ).expect[0]
+        return result
+
+    def average_dynamics_parallel(self, L, H_xi, xi_list, c_list, t_list, psi0,
+                                  n_noise, obs_list, args, options):
+        """
+        Runs multiple realizations of the stochastic master equation (Eq. 16)
+        in parallel using QuTiP’s `parallel_map`.
+
+        Parameters
+        ----------
+        L : Qobj
+            Lindblad operator or superoperator.
+        H_xi : Qobj
+            TODO: add better description
+        xi_list : np.ndarray
+            All ξ(t) trajectories.
+        c_list : list
+            Collapse operators.
+        t_list : np.ndarray
+            Time grid for integration.
+        psi0 : Qobj
+            Initial state.
+        n_noise : int
+            Number of stochastic realizations.
+        obs_list : list
+            TODO: add better description
+        args : dict
+            Arguments passed to QuTiP solvers.
+        options : Options
+            Solver options.
+
+        Returns
+        -------
+        dynamics_average : float
+            Mean value of the results.
+        sigma : float
+            Standard deviation of the results.
+        dynamics_list : np.ndarray
+            Individual trajectory results.
+        """
+
+        dynamics_list = parallel_map(
+            self.one_run,
+            range(n_noise),
+            task_args=(L, H_xi, xi_list, c_list, t_list, psi0,
+                       obs_list, args, options),
+            progress_bar=True)
+
+        dynamics_arr = np.array(dynamics_list)
+        dynamics_average = np.mean(dynamics_arr)
+        sigma = np.std(dynamics_arr)
+
+        return dynamics_average, sigma, dynamics_list


### PR DESCRIPTION
Preliminary implementation of the stochastic solver (SHSolver) based on PRX Quantum 4, 030316 (2023). Encapsulates coefficient computation, ξ(t) generation, and stochastic master-equation solving. Code is functional but still in draft, structure, inputs, and interfaces will be refined in upcoming iterations.